### PR TITLE
Don't wrap return@ line

### DIFF
--- a/velocidapter/src/main/java/com/bleacherreport/velocidapter/VelocidapterProcessor.kt
+++ b/velocidapter/src/main/java/com/bleacherreport/velocidapter/VelocidapterProcessor.kt
@@ -177,7 +177,7 @@ class VelocidapterProcessor : AbstractProcessor() {
                     ClassName("android.view", "LayoutInflater"),
                     layoutResIdMap[viewHolderClass]
                 )
-                addStatement("return@FunctionalAdapter %T(view)", ClassName.bestGuess(viewHolderClass))
+                addStatement("return@FunctionalAdapter·%T(view)", ClassName.bestGuess(viewHolderClass))
                 endControlFlow()
             }
             addStatement("throw RuntimeException(%S)", "Type not found ViewHolder set.")


### PR DESCRIPTION
A better solution would include using a KotlinPoet construct for `return@level` statements, but for now this works fine.

There's a related issue regarding import statements being wrapped when our ViewHolder or data types being too long, this is addressed in https://github.com/square/kotlinpoet/pull/554