### PR TITLE
Update KotlinPoet to 1.0.1 and refactor processor to clean up generated code

### DIFF
--- a/bintray/properties.gradle
+++ b/bintray/properties.gradle
@@ -1,5 +1,5 @@
 ext {
-    libraryVersion = '1.1.0-beta'
+    libraryVersion = '1.1.1-beta'
 
     // Nothing below this line should ever change
     bintrayRepo = 'velocidapter'

--- a/velocidapter/build.gradle
+++ b/velocidapter/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
-    api 'com.squareup:kotlinpoet:1.0.0-RC3'
+    api 'com.squareup:kotlinpoet:1.0.1'
     implementation "com.google.auto.service:auto-service:1.0-rc4"
     kapt "com.google.auto.service:auto-service:1.0-rc4"
 }


### PR DESCRIPTION
Imports of long package names no longer wrap in KotlinPoet 1.0.1, so this is just removing the workaround added in https://github.com/bleacherreport/Velocidapter/pull/10