### PR TITLE
fix for setEmpty()

### DIFF
--- a/velocidapter-android/src/main/java/com/bleacherreport/velocidapterandroid/DiffUpdateAdapter.kt
+++ b/velocidapter-android/src/main/java/com/bleacherreport/velocidapterandroid/DiffUpdateAdapter.kt
@@ -52,6 +52,7 @@ class FunctionalAdapter<T : ScopedDataList>(
 
     override fun setEmpty() {
         currentDataset = emptyList()
+        notifyDataSetChanged()
     }
 
     private fun checkIsDiffComparable(dataSet: T): Boolean {


### PR DESCRIPTION
setEmpty() in DiffUpdateAdapter wasn't calling notifyDataSetChanged(). This needs in asap, as calling setEmpty() can possibly result in a crash.